### PR TITLE
Fix low-res axis check in AxisGesture

### DIFF
--- a/src/logid/actions/gesture/AxisGesture.cpp
+++ b/src/logid/actions/gesture/AxisGesture.cpp
@@ -79,7 +79,7 @@ void AxisGesture::move(int16_t axis) {
     const auto threshold = _config.threshold.value_or(
             defaults::gesture_threshold);
     int32_t new_axis = _axis + axis;
-    int low_res_axis = InputDevice::getLowResAxis(axis);
+    int low_res_axis = InputDevice::getLowResAxis(_input_axis.value());
     int hires_remainder = _hires_remainder;
 
     if (new_axis > threshold) {


### PR DESCRIPTION
## Summary
- correct the argument passed to `getLowResAxis` in `AxisGesture`

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_687272e8dfb88324b19e9284d2033c4e